### PR TITLE
Change commit message string encoding. Fixes #3

### DIFF
--- a/src/main/scala/org/rvaughn/scm/cvs/FileParser.scala
+++ b/src/main/scala/org/rvaughn/scm/cvs/FileParser.scala
@@ -320,7 +320,7 @@ package org.rvaughn.scm.cvs {
     def decode(lines: List[Array[Byte]]): List[String] = {
       var l = List[String]() // built backwards
       for (line <- lines) {
-        l ::= StringCache(new String(line, "windows-1252").stripLineEnd)
+        l ::= StringCache(new String(line, "utf-8").stripLineEnd)
       }
       l.reverse
     }


### PR DESCRIPTION
Changes the default encoding of CVSNT commit messages to utf-8.
