### PR TITLE
Implementation of an file filter issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ section for complete details.
         --log=FILE                   log conversion progress to FILE
         --[no-]progress              show detailed conversion progress
     -q, --quiet                      suppress normal progress output (overrides --progress)
+        --exclude=ANTPATTERN         exclude files and folders matching this ant pattern
     -h, --help                       Show this message
 
 Options
@@ -387,6 +388,15 @@ This option suppresses all console output. This overrides the
 information to file, but suppress it in the console.
 
 By default, cvs-fast-export will report conversion progress.
+
+
+#### --exclude=ANTPATTERN
+This option tells cvs-fast-export to exclude all files and folders
+matching the ANTPATTERN. This option can be used several times to
+exclude multiple patterns. 
+The pattern matcher is using the Apache Ant syntax. 
+See http://ant.apache.org/manual/dirtasks.html#patterns for more information.
+
 
 
 #### -h, --help

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     compile 'org.scala-lang:scala-library:2.9.3'
     compile 'org.sellmerfud:optparse_2.9.1:1.0'
+    compile 'org.apache.ant:ant:1.9.6'
 }
 
 jar {

--- a/src/main/scala/org/rvaughn/scm/cvs/Config.scala
+++ b/src/main/scala/org/rvaughn/scm/cvs/Config.scala
@@ -48,6 +48,7 @@ package org.rvaughn.scm.cvs {
     var progress = false
     var logFile = ""
     var force = false
+    var excludePattern: Array[String] = Array.empty
 
     def importMarks = !marksImportFile.isEmpty
     def exportMarks = !marksExportFile.isEmpty
@@ -80,6 +81,6 @@ package org.rvaughn.scm.cvs {
     reqd("", "--log=FILE", "log conversion progress to FILE") { f: String => logFile = f }
     bool("", "--progress", "show detailed conversion progress") { progress = _ }
     flag("-q", "--quiet", "suppress normal progress output (overrides --progress)") { () => quiet = true }
+    reqd("", "--exclude=ANTPATTERN", "exclude files and folders matching this ant pattern") { s: String  => excludePattern = Config.excludePattern :+ s }
   }
-
 }


### PR DESCRIPTION
Provides the functional changes to exclude files and folders using the ant
syntax. Introduces the new option "--exclude=ANTPATTERN" which takes an ant file
matching pattern and excludes the matching files. This option can be
used multiple times.
